### PR TITLE
Changed the order of matrix products

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -72,7 +72,7 @@ viewProjMatrix extent = do
   let aspectRatio = fromIntegral width / fromIntegral height
   let view = lookAt (vec3 0 0 (-1)) (vec3 2 2 2) (vec3 0 0 0)
   let proj = perspective 0.1 20 (45/360*2*pi) aspectRatio
-  return $ proj %* view
+  return $ view %* proj
 
 
 runVulkanProgram :: IO ()
@@ -268,7 +268,7 @@ runVulkanProgram = runProgram checkStatus $ do
 
       shouldExit <- glfwMainLoop window $ do
         objMatrix <- objMatrixOverTime
-        writeIORef objTransformsRef [(translate3 $ vec3 0 1 1) %* objMatrix, objMatrix]
+        writeIORef objTransformsRef [objMatrix %* (translate3 $ vec3 0 1 1) , objMatrix]
 
         needRecreation <- drawFrame cap rdata `catchError` ( \err@(VulkanException ecode _) ->
           case ecode of

--- a/src/Lib/Vulkan/Engine/Simple3D.hs
+++ b/src/Lib/Vulkan/Engine/Simple3D.hs
@@ -162,7 +162,7 @@ recordAll
   objTransforms <- readIORef objTransformsRef
 
   forM_ (zip objTransforms objects) $ \(objTransform, object) -> do
-    recordObject pipelineLayout cmdBuf (viewProjTransform %* objTransform) object
+    recordObject pipelineLayout cmdBuf (objTransform %* viewProjTransform) object
 
   -- finishing up
   liftIO $ vkCmdEndRenderPass cmdBuf


### PR DESCRIPTION
Fix issue #1 : Changed the order of matrix products to account for the row-major layout of matrices in easytensor-v2